### PR TITLE
Enable snippets for pico-8-lua files

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,10 @@
 			{
 				"language": "pico-8",
 				"path": "./syntaxes/snippets.json"
+			},
+			{
+				"language": "pico-8-lua",
+				"path": "./syntaxes/snippets.json"
 			}
 		]
 	},


### PR DESCRIPTION
I started using a workflow that involved using #include to pull code from lua files, but missed the snippet suggestions while working in those lua files. This is especially useful for easy access to the Pico-8 glyph snippets.