### PR TITLE
feat: Add `region` code fold support & test files

### DIFF
--- a/syntaxes/language-configuration.json
+++ b/syntaxes/language-configuration.json
@@ -25,6 +25,13 @@
         ["\"", "\""],
         ["'", "'"]
     ],
+    // code folding region support
+    "folding": {
+      "markers": {
+        "start": "^\\s*(--)\\s*#?region\\b",
+        "end": "^\\s*(--)\\s*#?endregion\\b"
+      }
+    },
     "indentationRules": {
 		"increaseIndentPattern": "((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$",
 		"decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|(\\})|(\\)))"

--- a/testfiles/code-region.lua
+++ b/testfiles/code-region.lua
@@ -1,0 +1,36 @@
+-- #region With Name
+
+-- Region should fold all of this
+function test()
+  -- stupid simple function
+end
+
+function other_test()
+  -- another stupid function
+end
+
+-- #endregion With Name
+
+--#region Squished with label
+
+-- this should get folded too
+
+--#endregion Squished with label
+
+--#region
+
+-- Region without a label and no space between comment and region start and end
+
+--#endregion
+
+  -- #region Indented
+
+  -- indented regions work great too
+
+  -- #endregion
+
+-- #region
+
+-- Still collapsable
+
+-- #endregion The end region can have a label without the region having one

--- a/testfiles/code-region.p8
+++ b/testfiles/code-region.p8
@@ -1,0 +1,39 @@
+pico-8 cartridge // http://www.pico-8.com
+version 29
+__lua__
+-- #region With Name
+
+-- Region should fold all of this
+function test()
+  -- stupid simple function
+end
+
+function other_test()
+  -- another stupid function
+end
+
+-- #endregion With Name
+
+--#region Squished with label
+
+-- this should get folded too
+
+--#endregion Squished with label
+
+--#region
+
+-- Region without a label and no space between comment and region start and end
+
+--#endregion
+
+  -- #region Indented
+
+  -- indented regions work great too
+
+  -- #endregion
+
+-- #region
+
+-- Still collapsable
+
+-- #endregion The end region can have a label without the region having one


### PR DESCRIPTION
If this PR is accepted, it will add support for code folding using `regions` and test files associated with different `region` possibilities.

Code folding is really nice using regions and I use it all the time. I noticed that this language server didn't have it and saw that it was fairly easy to add support for it.

The test files show the different ways that a region can start and end in both of the supported file formats.

As far as usefulness, you can turn this chunk of code:
```lua
-------------------------------
-- palettes
-------------------------------

function init_palettes()
 local a=0x5d00
 for p=0,15 do
  for c=0,15 do
   poke(a,bor(sget(p,c),c==14 and 0x80))
   a+=1
  end
 end
end

function set_palette(no,off)
 memcpy(off or 0x5f00,
  0x5d00+shl(flr(no),4),
  16)
end

```

To this:
```lua

-- #region palettes

function init_palettes()
 local a=0x5d00
 for p=0,15 do
  for c=0,15 do
   poke(a,bor(sget(p,c),c==14 and 0x80))
   a+=1
  end
 end
end

function set_palette(no,off)
 memcpy(off or 0x5f00,
  0x5d00+shl(flr(no),4),
  16)
end
-- #endregion
```

The second would allow you to fold the code in between the region comments so you can hide it and worry about the stuff you want to.