### PR TITLE
Add `__sfx__` and `__music__` to lexer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"editor.insertSpaces": false,
 	"typescript.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
+	"editor.formatOnSave": false,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	}

--- a/client/src/semantic-token-provider.ts
+++ b/client/src/semantic-token-provider.ts
@@ -25,9 +25,7 @@ const provider: DocumentSemanticTokensProvider = {
       if (line.text == '__lua__') {
         inLua = true;
         continue;
-      } else if (inLua &&
-          (line.text === '__gfx__' || line.text === '__label__' || line.text === '__gff__' || line.text === '__map__')
-      ) {
+      } else if (inLua && [ '__gfx__', '__label__', '__gff__', '__map__', '__sfx__', '__music__' ].includes(line.text)) {
         inLua = false;
         continue;
       }

--- a/server/src/parser/lexer.ts
+++ b/server/src/parser/lexer.ts
@@ -1007,8 +1007,5 @@ export function isP8BeginningOfCodeSection(value: string): boolean {
 }
 
 export function isP8EndOfCodeSection(value: string): boolean {
-  return value === '__gfx__'
-    || value === '__label__'
-    || value === '__gff__'
-    || value === '__map__';
+  return [ '__gfx__', '__label__', '__gff__', '__map__', '__sfx__', '__music__' ].includes(value);
 }

--- a/server/src/parser/test/lexer.test.ts
+++ b/server/src/parser/test/lexer.test.ts
@@ -273,6 +273,30 @@ __gfx__
     assertNoMoreTokens(tokens);
   });
 
+  it('skips __sfx__ section', () => {
+    const code = `pico-8 cartridge // http://www.pico-8.com
+version 42
+__lua__
+
+__sfx__
+013c01001815000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+`;
+    const tokens = getLexedTokens(code);
+    assertNoMoreTokens(tokens);
+  });
+
+  it('skips __music__ section', () => {
+    const code = `pico-8 cartridge // http://www.pico-8.com
+version 42
+__lua__
+
+__music__
+00 01424344
+`;
+    const tokens = getLexedTokens(code);
+    assertNoMoreTokens(tokens);
+  });
+
   describe('error handling', () => {
     it('returns an error for an unterminated string literal', () => {
       assert.throws(() => {

--- a/server/src/parser/test/parser.test.ts
+++ b/server/src/parser/test/parser.test.ts
@@ -698,6 +698,28 @@ __gfx__
     deepEqualsAST(code, []);
   });
 
+  it('skips __sfx__ section', () => {
+    const code = `pico-8 cartridge // http://www.pico-8.com
+version 42
+__lua__
+
+__sfx__
+013c01001815000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+`;
+    deepEqualsAST(code, []);
+  });
+
+  it('skips __music__ section', () => {
+    const code = `pico-8 cartridge // http://www.pico-8.com
+version 42
+__lua__
+
+__music__
+00 01424344
+`;
+    deepEqualsAST(code, []);
+  });
+
   it('parses low.p8', () => {
     const { errors } = parse(getTestFileContents('low.p8'));
     eq(errors.length, 0, 'Unexpected errors: ' + errors.map(e => `[${e.bounds.start.line}:${e.bounds.end.column}] ${e.message}`).join(','));

--- a/syntaxes/pico-8.tmLanguage.json
+++ b/syntaxes/pico-8.tmLanguage.json
@@ -6,7 +6,7 @@
     "repository": {
       "lua": {
         "begin": "__lua__",
-        "end": "(__gfx__|__label__|__gff__|__map__)",
+        "end": "(__gfx__|__label__|__gff__|__map__|__sfx__|__music__)",
         "beginCaptures": {
           "0": { "name": "punctuation.code.open" }
         },


### PR DESCRIPTION
Closes #69

- Sets `"editor.formatOnSave": false` for the vscode workspace.
  As Prettier clashes with the Eslint formatting rules of this repo, this is useful for devs like me who has `formatOnSave` set in their user-settings, and otherwise has to use `> File: Save without formatting` to save.
- Add failing tests for `__sfx__` and `__music__` to lexer and parser. (Check out the test commit to see them fail)
- Fix tests by adding `__sfx__` and `__music__` to
  - `client/src/semantic-token-provider.ts`
  - `server/src/parser/lexer.ts`
  - `syntaxes/pico-8.tmLanguage.json`
