### PR TITLE
fix: region comment not collapsing issue

### DIFF
--- a/server/src/parser/folding-regions.ts
+++ b/server/src/parser/folding-regions.ts
@@ -72,27 +72,29 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
     const commentText = comment.value.trim();
 
     // Handle #region and #endregion markers
-    if (regionStartRegex.test(commentText)) {
-      const nameMatch = commentText.match(regionStartRegex);
-      const label = nameMatch && nameMatch[1] ? nameMatch[1].trim() : '';
+    const regionStartMatch = regionStartRegex.exec(commentText);
+    if (regionStartMatch) {
+      const label = regionStartMatch[1] ? regionStartMatch[1].trim() : '';
       const name = label || 'region';
       regionStack.push({ startLine: comment.loc!.start.line, name: name, isDefaultName: !label });
-    } else if (regionEndRegex.test(commentText)) {
-      if (regionStack.length > 0) {
-        const startRegion = regionStack.pop()!;
-        const endNameMatch = commentText.match(regionEndRegex);
-        const endLabel = endNameMatch && endNameMatch[1] ? endNameMatch[1].trim() : '';
+    } else {
+      const regionEndMatch = regionEndRegex.exec(commentText);
+      if (regionEndMatch) {
+        if (regionStack.length > 0) {
+          const startRegion = regionStack.pop()!;
+          const endLabel = regionEndMatch[1] ? regionEndMatch[1].trim() : '';
 
-        let finalName = startRegion.name;
-        if (startRegion.isDefaultName && endLabel) {
-          finalName = endLabel;
+          let finalName = startRegion.name;
+          if (startRegion.isDefaultName && endLabel) {
+            finalName = endLabel;
+          }
+
+          foldingRegions.push({
+            name: finalName,
+            startLine: startRegion.startLine - 1,
+            endLine: comment.loc!.start.line - 1,
+          });
         }
-
-        foldingRegions.push({
-          name: finalName,
-          startLine: startRegion.startLine - 1,
-          endLine: comment.loc!.start.line - 1,
-        });
       }
     }
 

--- a/server/src/parser/folding-regions.ts
+++ b/server/src/parser/folding-regions.ts
@@ -46,9 +46,9 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
   let currentFoldingName: string | undefined = undefined;
 
   // Stack to handle nested #region comments
-  const regionStack: { startLine: number; name: string }[] = [];
+  const regionStack: { startLine: number; name: string; isDefaultName: boolean }[] = [];
   const regionStartRegex = /^#region\s*(.*)$/;
-  const regionEndRegex = /^#endregion\b/;
+  const regionEndRegex = /^#endregion\s*(.*)$/;
 
   // Handle the initial region before the first '-->8' comment, if __lua__ exists.
   if (luaStartLine !== undefined) {
@@ -74,13 +74,22 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
     // Handle #region and #endregion markers
     if (regionStartRegex.test(commentText)) {
       const nameMatch = commentText.match(regionStartRegex);
-      const name = nameMatch && nameMatch[1] ? nameMatch[1].trim() : 'region';
-      regionStack.push({ startLine: comment.loc!.start.line, name: name });
+      const label = nameMatch && nameMatch[1] ? nameMatch[1].trim() : '';
+      const name = label || 'region';
+      regionStack.push({ startLine: comment.loc!.start.line, name: name, isDefaultName: !label });
     } else if (regionEndRegex.test(commentText)) {
       if (regionStack.length > 0) {
         const startRegion = regionStack.pop()!;
+        const endNameMatch = commentText.match(regionEndRegex);
+        const endLabel = endNameMatch && endNameMatch[1] ? endNameMatch[1].trim() : '';
+
+        let finalName = startRegion.name;
+        if (startRegion.isDefaultName && endLabel) {
+          finalName = endLabel;
+        }
+
         foldingRegions.push({
-          name: startRegion.name,
+          name: finalName,
           startLine: startRegion.startLine - 1,
           endLine: comment.loc!.start.line - 1,
         });
@@ -110,7 +119,7 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
     const startRegion = regionStack.pop()!;
     foldingRegions.push({
       name: startRegion.name,
-      startLine: startRegion.startLine - 1,
+      startLine: startRegion.startLine,
       endLine: textDocument.lineCount - 1, // Fold to the end of the file
     });
   }

--- a/server/src/parser/folding-regions.ts
+++ b/server/src/parser/folding-regions.ts
@@ -45,6 +45,11 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
   let currentFoldingStartLine: number | undefined = undefined;
   let currentFoldingName: string | undefined = undefined;
 
+  // Stack to handle nested #region comments
+  const regionStack: { startLine: number; name: string }[] = [];
+  const regionStartRegex = /^#region\s*(.*)$/;
+  const regionEndRegex = /^#endregion\b/;
+
   // Handle the initial region before the first '-->8' comment, if __lua__ exists.
   if (luaStartLine !== undefined) {
     const firstFoldingComment = sortedComments.find(comment =>
@@ -64,6 +69,24 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
   // Iterate through comments to find '-->8' markers and create folding regions.
   for (let i = 0; i < sortedComments.length; i++) {
     const comment = sortedComments[i];
+    const commentText = comment.value.trim();
+
+    // Handle #region and #endregion markers
+    if (regionStartRegex.test(commentText)) {
+      const nameMatch = commentText.match(regionStartRegex);
+      const name = nameMatch && nameMatch[1] ? nameMatch[1].trim() : 'region';
+      regionStack.push({ startLine: comment.loc!.start.line, name: name });
+    } else if (regionEndRegex.test(commentText)) {
+      if (regionStack.length > 0) {
+        const startRegion = regionStack.pop()!;
+        foldingRegions.push({
+          name: startRegion.name,
+          startLine: startRegion.startLine - 1,
+          endLine: comment.loc!.start.line - 1,
+        });
+      }
+    }
+
     if (comment.raw === '-->8') {
       if (currentFoldingStartLine !== undefined) {
         foldingRegions.push(createFoldingRegion(currentFoldingName!, currentFoldingStartLine, comment.loc!.start.line - 2, tabNumber++));
@@ -81,6 +104,24 @@ export function getFoldingRegions(textDocument: TextDocument, comments: Comment_
     }
     foldingRegions.push(createFoldingRegion(currentFoldingName!, currentFoldingStartLine, endLine, tabNumber++));
   }
+
+  // Close any remaining open #region markers at the end of the file
+  while (regionStack.length > 0) {
+    const startRegion = regionStack.pop()!;
+    foldingRegions.push({
+      name: startRegion.name,
+      startLine: startRegion.startLine - 1,
+      endLine: textDocument.lineCount - 1, // Fold to the end of the file
+    });
+  }
+
+  // Sort the folding regions for consistent output
+  foldingRegions.sort((a, b) => {
+    if (a.startLine !== b.startLine) {
+      return a.startLine - b.startLine;
+    }
+    return a.endLine - b.endLine;
+  });
 
   return foldingRegions;
 }

--- a/server/src/parser/test/folding-range.test.ts
+++ b/server/src/parser/test/folding-range.test.ts
@@ -205,6 +205,87 @@ end
     ]);
   });
 
+  it('should create folding regions when #region has a label and #endregion does not', () => {
+    const code = `
+-- #region MyLabeledRegion
+local a = 1
+-- #endregion
+`.trim();
+    const textDocument = TextDocument.create('test.lua', 'pico-8-lua', 0, code);
+    const { comments } = parse(code);
+    const regions = getFoldingRegions(textDocument, comments || []);
+
+    deepEquals(regions, [
+      { name: 'MyLabeledRegion', startLine: 0, endLine: 2 },
+    ]);
+  });
+
+  it('should create folding regions when #region has no label and #endregion has a label', () => {
+    const code = `
+-- #region
+local a = 1
+-- #endregion MyEndRegion
+`.trim();
+    const textDocument = TextDocument.create('test.lua', 'pico-8-lua', 0, code);
+    const { comments } = parse(code);
+    const regions = getFoldingRegions(textDocument, comments || []);
+
+    deepEquals(regions, [
+      { name: 'MyEndRegion', startLine: 0, endLine: 2 },
+    ]);
+  });
+
+  it('should prioritize #region label over #endregion label if both exist', () => {
+    const code = `
+-- #region StartLabel
+local a = 1
+-- #endregion EndLabel
+`.trim();
+    const textDocument = TextDocument.create('test.lua', 'pico-8-lua', 0, code);
+    const { comments } = parse(code);
+    const regions = getFoldingRegions(textDocument, comments || []);
+
+    deepEquals(regions, [
+      { name: 'StartLabel', startLine: 0, endLine: 2 },
+    ]);
+  });
+
+  it('should handle deeply nested #region and #endregion markers with labels', () => {
+    const code = `
+-- #region Outer
+  -- #region Middle
+    -- #region Inner
+    local x = 1
+    -- #endregion Inner
+  -- #endregion Middle
+-- #endregion Outer
+`.trim();
+    const textDocument = TextDocument.create('test.lua', 'pico-8-lua', 0, code);
+    const { comments } = parse(code);
+    const regions = getFoldingRegions(textDocument, comments || []);
+
+    deepEquals(regions, [
+      { name: 'Outer', startLine: 0, endLine: 6 },
+      { name: 'Middle', startLine: 1, endLine: 5 },
+      { name: 'Inner', startLine: 2, endLine: 4 },
+    ]);
+  });
+
+  it('should create a folding region to the end of the file if #region is not closed', () => {
+    const code = `
+-- #region UnclosedRegion
+local a = 1
+local b = 2
+`.trim();
+    const textDocument = TextDocument.create('test.lua', 'pico-8-lua', 0, code);
+    const { comments } = parse(code);
+    const regions = getFoldingRegions(textDocument, comments || []);
+
+    deepEquals(regions, [
+      { name: 'UnclosedRegion', startLine: 1, endLine: 2 },
+    ]);
+  });
+
   it('should create folding regions for tabs.p8 using TestFilesResolver', () => {
     const filename = 'tabs.p8';
     const code = getTestFileContents(filename);

--- a/server/src/parser/test/folding-range.test.ts
+++ b/server/src/parser/test/folding-range.test.ts
@@ -179,6 +179,32 @@ __gfx__
     ]);
   });
 
+  it('should create folding regions for #region and #endregion markers', () => {
+    const code = `
+-- #region My Region
+local a = 1
+local b = 2
+-- #endregion
+
+-- #region Another Region
+function foo()
+  -- #region Nested Region
+  print("hello")
+  -- #endregion
+end
+-- #endregion
+`.trim();
+    const textDocument = TextDocument.create('test.lua', 'pico-8-lua', 0, code);
+    const { comments } = parse(code);
+    const regions = getFoldingRegions(textDocument, comments || []);
+
+    deepEquals(regions, [
+      { name: 'My Region', startLine: 0, endLine: 3 },
+      { name: 'Another Region', startLine: 5, endLine: 11 },
+      { name: 'Nested Region', startLine: 7, endLine: 9 },
+    ]);
+  });
+
   it('should create folding regions for tabs.p8 using TestFilesResolver', () => {
     const filename = 'tabs.p8';
     const code = getTestFileContents(filename);

--- a/syntaxes/language-configuration.json
+++ b/syntaxes/language-configuration.json
@@ -25,13 +25,6 @@
         ["\"", "\""],
         ["'", "'"]
     ],
-    // code folding region support
-    "folding": {
-        "markers": {
-            "start": "^\\s*(--)\\s*#?region\\b",
-            "end": "^\\s*(--)\\s*#?endregion\\b"
-        }
-    },
     "indentationRules": {
         "increaseIndentPattern": "((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$",
         "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|(\\})|(\\)))"


### PR DESCRIPTION
While defining a custom FoldingRegion in #72, I confirmed that the feature added in #49 was not functioning.

I modified it to work and removed the settings that no longer functioned.

I also added some tests for the region comment.