### PR TITLE
Add exclusions to settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,15 @@
 					"default": 100,
 					"description": "Controls the maximum number of problems produced by the server."
 				},
+				"pico8-ls.exclude": {
+					"scope": "resource",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"description": "Configure glob patterns for excluding files and folders from parsing. Examples: 'backup/**' or just 'backup/'"
+				},
 				"pico8-ls.trace.server": {
 					"scope": "window",
 					"type": "string",


### PR DESCRIPTION
Slightly particular to my workflow but potentially beneficial for all. Certain files in my workspace — particularly those using `#include` — might throw problems in VSCode I know I can ignore, but my visual cortex is distracted by the errors; I'm just adding the option to exclude these. 

e.g. if I close a running Pico window and it creates a `last_run.p8` in backup, it might do something like the below:

<img width="917" height="280" alt="image" src="https://github.com/user-attachments/assets/8560ba6f-275a-40b7-9974-9dcaae1724c2" />

